### PR TITLE
Recommend switching away from procmail

### DIFF
--- a/lib/Log/Procmail.pm
+++ b/lib/Log/Procmail.pm
@@ -10,7 +10,7 @@ use UNIVERSAL ();
 use vars qw/ $VERSION /;
 local $^W = 1;
 
-$VERSION = '0.12';
+$VERSION = '0.13';
 
 my %month;
 @month{qw/ Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec /} = ( 0 .. 11 );

--- a/lib/Log/Procmail.pm
+++ b/lib/Log/Procmail.pm
@@ -224,6 +224,11 @@ Log::Procmail - Perl extension for reading procmail logfiles.
 
 Log::Procmail reads procmail(1) logfiles and returns the abstracts one by one.
 
+Note:  The most recent procmail maintainer, Philip Geunther, says
+L<the code is not safe and should not be used|https://marc.info/?l=openbsd-ports&m=141634350915839&w=2>.
+There have been no releases since 2001 when Philip stopped maintaining it,
+you should find a replacement.
+
 =over 4
 
 =item $log = Log::Procmail->new( @files );


### PR DESCRIPTION
There have been no releases for 20 years and the most recent maintainer recommends against using it, but unfortunately that information is not widely available.   [Wikipedia has several pointers to replacements](https://en.wikipedia.org/wiki/Procmail#Replacements).

I'm not sure this is a great place to document this, but the more places it can be mentioned the better.