### PR TITLE
clear the eof flag to read past the previous end of file

### DIFF
--- a/lib/Log/Procmail.pm
+++ b/lib/Log/Procmail.pm
@@ -36,6 +36,8 @@ sub next {
     {
         my $read;
 
+        # ensure we can read past the previous end of file
+        $fh->clearerr if $fh->eof;
       LINE:
         while (<$fh>) {
             $read++;


### PR DESCRIPTION
The current development perl fixes a bug where readline() would clear the eof and error flags for a stream after trying to read at end of file, Log::Procmail depended on this bug